### PR TITLE
Fix compilation

### DIFF
--- a/source/funkin/backend/DiscordRpc.hx
+++ b/source/funkin/backend/DiscordRpc.hx
@@ -12,7 +12,7 @@ class DiscordRPC {
 	public static var clientID(default, set):String = '1285413579893506118';
 	
 	#if hxdiscord_rpc
-	public static var presence:DiscordRichPresence = DiscordRichPresence.create();
+	public static var presence:DiscordRichPresence = new DiscordRichPresence();
 	
 	public static function prepare() {
 		initialize();
@@ -21,11 +21,11 @@ class DiscordRPC {
 	public static function initialize() {
 		if (initialized) return;
 		
-		final handlers:DiscordEventHandlers = DiscordEventHandlers.create();
+		final handlers:DiscordEventHandlers = new DiscordEventHandlers();
 		handlers.ready = cpp.Function.fromStaticFunction(onReady);
 		handlers.disconnected = cpp.Function.fromStaticFunction(onDisconnected);
 		handlers.errored = cpp.Function.fromStaticFunction(onError);
-		Discord.Initialize(clientID, cpp.RawPointer.addressOf(handlers), 1, null);
+		Discord.Initialize(clientID, cpp.RawPointer.addressOf(handlers), true, null);
 		
 		Thread.create(() -> {
 			while (true) {


### PR DESCRIPTION
Since `hxdiscord_rpc` 1.3.0, which released yesterday, the following changes at https://github.com/MAJigsaw77/hxdiscord_rpc/commit/bf0f15492e07d3deeee173e937a0a857f563508b have broken compiling for this project:
- The `autoRegister` argument went from an `Int` to a `Bool`,
- `create` static functions were replaced with constructor alloc.

This PR modifies `DiscordRpc` to allow compiling again.